### PR TITLE
Fix crash of stove on server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Disable autocrlf on generated files, they always generate with LF
+# Add any extra files or paths here to make git stop saying they
+# are changed when only line endings change.
+src/generated/**/.cache/cache text eol=lf
+src/generated/**/*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+
+# other
+eclipse
+run
+
+# Files from Forge MDK
+forge*changelog.txt

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven {
+            name = 'MinecraftForge'
+            url = 'https://maven.minecraftforge.net/'
+        }
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+}

--- a/src/main/java/cn/foggyhillside/festival_delicacies/blocks/entities/StoveEntity.java
+++ b/src/main/java/cn/foggyhillside/festival_delicacies/blocks/entities/StoveEntity.java
@@ -5,7 +5,6 @@ import cn.foggyhillside.festival_delicacies.blocks.screen.StoveMenu;
 import cn.foggyhillside.festival_delicacies.recipe.StoveRecipe;
 import cn.foggyhillside.festival_delicacies.registry.ModBlockEntities;
 import cn.foggyhillside.festival_delicacies.tag.ModTags;
-import cn.foggyhillside.festival_delicacies.util.RecipeUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -149,9 +148,10 @@ public class StoveEntity extends BlockEntity implements MenuProvider {
     }
 
     private static boolean canOutput(StoveEntity entity, Optional<StoveRecipe> recipe) {
+        var registryAccess = entity.getLevel().registryAccess();
         return entity.itemStackHandler.getStackInSlot(10) == ItemStack.EMPTY
-                || (entity.itemStackHandler.getStackInSlot(10).getItem() == RecipeUtils.getResultItem(recipe.get()).getItem()
-                && entity.itemStackHandler.getStackInSlot(10).getCount() < RecipeUtils.getResultItem(recipe.get()).getItem().getMaxStackSize());
+                || (entity.itemStackHandler.getStackInSlot(10).getItem() == recipe.get().getResultItem(registryAccess).getItem()
+                && entity.itemStackHandler.getStackInSlot(10).getCount() < recipe.get().getResultItem(registryAccess).getMaxStackSize());
     }
 
     private static boolean hasRecipe(StoveEntity entity, Optional<StoveRecipe> recipe) {
@@ -192,7 +192,7 @@ public class StoveEntity extends BlockEntity implements MenuProvider {
             }
             entity.itemStackHandler.setStackInSlot(10, new ItemStack(recipe.get().getResultItem(level.registryAccess()).getItem(),
                     entity.itemStackHandler.getStackInSlot(10).getCount()
-                            + RecipeUtils.getResultItem(recipe.get()).getCount()));
+                            + recipe.get().getResultItem(level.registryAccess()).getCount()));
             entity.resetProgress();
         }
     }

--- a/src/main/java/cn/foggyhillside/festival_delicacies/util/RecipeUtils.java
+++ b/src/main/java/cn/foggyhillside/festival_delicacies/util/RecipeUtils.java
@@ -5,11 +5,14 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class RecipeUtils {
     public RecipeUtils() {
     }
 
+    @OnlyIn(Dist.CLIENT)
     public static ItemStack getResultItem(Recipe<?> recipe) {
         Minecraft minecraft = Minecraft.getInstance();
         ClientLevel level = minecraft.level;


### PR DESCRIPTION
[crash-2024-10-25_13.29.45-server.txt](https://github.com/user-attachments/files/17516740/crash-2024-10-25_13.29.45-server.txt)
您一看肯定就知道是啥问题，就不赘述了。
我还添加了一些文件，使得这个仓库被clone后可以直接运行。原来还有点问题。